### PR TITLE
Fix memory leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,4 @@ require (
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
 )
 
-replace golang.org/x/crypto => github.com/tsurubee/sshr.crypto v0.0.0-20190518234326-629a3c1db872
+replace golang.org/x/crypto => github.com/tsurubee/sshr.crypto v0.0.0-20200227133524-08ab068d7cff

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/tsurubee/sshr.crypto v0.0.0-20190518234326-629a3c1db872 h1:YIb7te7wOeVYmBfqKvzMdUN5SUp1f3a4fMjtmDvWwiU=
-github.com/tsurubee/sshr.crypto v0.0.0-20190518234326-629a3c1db872/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
+github.com/tsurubee/sshr.crypto v0.0.0-20200227133524-08ab068d7cff/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tsurubee/sshr.crypto v0.0.0-20200227133524-08ab068d7cff h1:1W+d234ajXHDtvEcacgcFZIFG9+L3Sjq4uZht0skVXw=
 github.com/tsurubee/sshr.crypto v0.0.0-20200227133524-08ab068d7cff/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Since sshr probably has a memory leak bug, the purpose of this PR is to investigate the cause of the leak and fix it.  

According to the results of investigating the number of goroutines using [pprof](https://github.com/google/pprof), the goroutine shown below seems to be leaking.   This goroutine is used to read and write packets between the sshr server and the upstream server.
```
goroutine profile: total 9
2 @ 0x42f78b 0x42f833 0x406a2d 0x406805 0x62cb3b 0x45d501
#	0x62cb3a	golang.org/x/crypto/ssh.(*ProxyConn).Wait.func2+0x7a	/root/go/pkg/mod/github.com/tsurubee/sshr.crypto@v0.0.0-20190518234326-629a3c1db872/ssh/proxy.go:286
```