### PR TITLE
Fix sshr.crypto version strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,4 @@ require (
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
 )
 
-replace golang.org/x/crypto => github.com/tsurubee/sshr.crypto v0.0.0-20200227133524-08ab068d7cff
+replace golang.org/x/crypto => github.com/tsurubee/sshr.crypto v0.0.0-20200227133732-5db8c8aac292

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/tsurubee/sshr.crypto v0.0.0-20200227133524-08ab068d7cff h1:1W+d234ajXHDtvEcacgcFZIFG9+L3Sjq4uZht0skVXw=
-github.com/tsurubee/sshr.crypto v0.0.0-20200227133524-08ab068d7cff/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
+github.com/tsurubee/sshr.crypto v0.0.0-20200227133732-5db8c8aac292 h1:6VOMFyovYqCmF95nc8GDreYVWa8f001NAjyPpddtDGE=
+github.com/tsurubee/sshr.crypto v0.0.0-20200227133732-5db8c8aac292/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
I fixed the version strings of sshr.crypto because I used the old version by mistake.
This PR is related to the PR below.  
https://github.com/tsurubee/sshr/pull/30#issuecomment-593246682