### PR TITLE
close proxy up/downstream connections if connection is not nil

### DIFF
--- a/sshr/server.go
+++ b/sshr/server.go
@@ -89,6 +89,10 @@ func (server *SSHServer) serve() error {
 			}
 			if err != nil {
 				logger.infof("Connection from %s closed. %v", tcpConn.RemoteAddr().String(), err)
+				// close sockets if proxy conn is not nil and got error
+				if p != nil {
+					p.Close()
+				}
 				return err
 			}
 			logger.infof("Establish a proxy connection between %s and %s", tcpConn.RemoteAddr().String(), p.DestinationHost)


### PR DESCRIPTION
## Overview

I found sshr got a problem. If newSSHProxyConn return error with not nil proxy conn, just close goroutine without close proxy conn's net connections.

It makes OS's established net socket piling up and probably occur leak memory.

So In this PR, close proxy connection when got error in newSSHProxyConn function.

## Test case

Here is the sample case.

- if user tries to login with not exist user

```
$ ssh invalid_user@sshr.sample.com -p 2222
```

- sshr print out log like connection disconnected

```
sshr[32036]: time="2023-05-22T16:10:55+09:00" level=info msg="SSH Client connected. ClientIP=xxx.xxx.xxx.xxx:54101"
sshr[32036]: time="2023-05-22T16:10:55+09:00" level=debug msg="cannot get domain from webapi server: user does not exists"
sshr[32036]: time="2023-05-22T16:10:55+09:00" level=info msg="[user:invalid_user] Connection from xxx.xxx.xxx.xxx:54101 closed. cannot get domain from webapi server: user does not exists"
```

- but in sshr server, connection is still established until client shutdown ssh client by interrupt

```
# netstat -antop | grep 2222
tcp        0      0 0.0.0.0:2222            0.0.0.0:*               LISTEN      14199/start_server   off (0.00/0/0)
tcp        0      0 yyy.yyy.yyy.yyy:2222       xxx.xxx.xxx.xxx:54101   ESTABLISHED 14203/sshr     keepalive (11.91/0/0)
```

- and client's ssh session is not disconnect until got signal like ctrl+C

```
$ ssh invalid_user@sshr.sample.com -p 2222
^C
$ 
```

## Other

I write other PR in sshr.crypto for closing ssh conn more safe.
https://github.com/tsurubee/sshr.crypto/pull/5
